### PR TITLE
More granular retention (optional)

### DIFF
--- a/app/helpers/servers_helper.rb
+++ b/app/helpers/servers_helper.rb
@@ -1,2 +1,9 @@
 module ServersHelper
+  def display_retention(server)
+    if server.retention_days.to_i > 0
+      "#{server.retention_days.to_i} daily, #{server.retention_weeks.to_i} weekly, #{server.retention_months.to_i} monthly"
+    else
+      server.keep_snapshots.to_s
+    end
+  end
 end

--- a/app/models/backup_job.rb
+++ b/app/models/backup_job.rb
@@ -284,7 +284,7 @@ class BackupJob < ActiveRecord::Base
         brackets[bracket].each do |snap|
           if previous
             time_diff = snap - previous
-            if !min_time_diff || min_time_diff > time_diff
+            if !min_time_diff || min_time_diff >= time_diff
               min_time_diff = time_diff
               candidate = first_candidate ? snap : previous
               #puts "candidate #{candidate} #{time_diff}"

--- a/app/models/backup_job.rb
+++ b/app/models/backup_job.rb
@@ -235,14 +235,11 @@ class BackupJob < ActiveRecord::Base
       last_maxage = bracket_maxage[bracket]
       brackets[bracket] = []
     end
-    #puts bracket_retention.inspect
-    #puts bracket_maxage.inspect
 
     # Assign each snapshot to a bracket of time.
     latest = snaps.sort.max
     snaps.sort.each do |snap|
       age = latest - snap
-      #puts snap.inspect + ' ' + age.inspect
       out_of_range = true
       BRACKETS.each do |bracket|
         if age < bracket_maxage[bracket]
@@ -287,7 +284,6 @@ class BackupJob < ActiveRecord::Base
             if !min_time_diff || min_time_diff >= time_diff
               min_time_diff = time_diff
               candidate = first_candidate ? snap : previous
-              #puts "candidate #{candidate} #{time_diff}"
             end
             first_candidate = false
           end

--- a/app/models/backup_job.rb
+++ b/app/models/backup_job.rb
@@ -253,7 +253,20 @@ class BackupJob < ActiveRecord::Base
       end
       if out_of_range
         # If the snapshot is in none of the brackets, we have our best candidate!
+        t1 = Time.at(snap).strftime("%F %H:%M")
+        logger.debug "selecting snapshot #{snap} #{t1}: out of range"
         return snap.to_s
+      end
+    end
+
+    BRACKETS.each do |bracket|
+      if brackets[bracket].size == 0
+        logger.debug "bracket #{bracket} is empty"
+      else
+        count=brackets[bracket].size
+        t1 = Time.at(brackets[bracket].first).strftime("%F %H:%M")
+        t2 = Time.at(brackets[bracket].last).strftime("%F %H:%M")
+        logger.debug "bracket #{bracket}: #{count} entries from #{t1} to #{t2}"
       end
     end
 
@@ -278,6 +291,10 @@ class BackupJob < ActiveRecord::Base
           previous = snap
         end
       end
+    end
+    if candidate
+      t1 = Time.at(candidate).strftime("%F %H:%M")
+      logger.debug "selecting snapshot #{candidate} #{t1}: least time difference"
     end
     candidate ? candidate.to_s : nil
   end

--- a/app/models/backup_job.rb
+++ b/app/models/backup_job.rb
@@ -274,19 +274,22 @@ class BackupJob < ActiveRecord::Base
     # see if we have too many snapshots in that bracket. If we do,
     # we select the one with the smallest time difference to its
     # successor (and eventual replacement).
+    # Exception: we never select the oldest snapshot in a bracket.
     candidate = nil
     BRACKETS.each do |bracket|
       if brackets[bracket].size > bracket_retention[bracket]
         previous = nil
         min_time_diff = nil
+        first_candidate = true
         brackets[bracket].each do |snap|
           if previous
             time_diff = snap - previous
             if !min_time_diff || min_time_diff > time_diff
               min_time_diff = time_diff
-              candidate = previous
+              candidate = first_candidate ? snap : previous
               #puts "candidate #{candidate} #{time_diff}"
             end
+            first_candidate = false
           end
           previous = snap
         end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -9,6 +9,12 @@ class Server < ActiveRecord::Base
          :unless => Proc.new { |server| server.window_stop.blank?  }
 	validates_presence_of :comment, :unless => Proc.new { |s| s.backup_server_id == nil || s.enabled == true },
 				 :message => 'You must enter a ticket number in the comment field when you disable a backup.'
+  validates_inclusion_of :retention_weeks, :in => 1..9,
+         :message => 'Should be a valid number of weeks! Ranging from 1 to 9',
+         :unless => Proc.new { |server| server.retention_days.to_i == 0 }
+  validates_inclusion_of :retention_months, :in => 0..24,
+         :message => 'Should be a valid number of months! Ranging from 0 to 24',
+         :unless => Proc.new { |server| server.retention_days.to_i == 0 }
 
   has_many :profilizations, :dependent => :destroy
   has_many :profiles, :through => :profilizations, :include => [:includes, :excludes, :splits]
@@ -35,6 +41,9 @@ class Server < ActiveRecord::Base
     self.path = '/' unless self.path
     self.interval_hours=24 unless self.interval_hours
     self.keep_snapshots = 21 unless self.keep_snapshots
+    self.retention_days = 0 unless self.retention_days
+    self.retention_weeks = 0 unless self.retention_weeks
+    self.retention_months = 0 unless self.retention_months
   end
 
   def previous_jobs

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -20,7 +20,8 @@
       <%= f.input :keep_snapshots, :required => true, :label => 'Keep this number of snapshots',
         :hint => 'Normally, Retcon uses this value as the maximum number of snapshots to keep. ' +
         'This setting will be overridden if daily retention is defined. ' +
-        'In both cases, this setting affects the number of job logs that Retcon keeps.' %>
+        'In both cases, this setting affects the number of job logs that Retcon keeps, ' +
+        'so do not lower this value when you use daily retention.' %>
       <%= f.input :retention_days, :required => false, :label => 'Daily snapshots to retain' %>
       <%= f.input :retention_weeks, :required => false, :label => 'Weekly snapshots to retain' %>
       <%= f.input :retention_months, :required => false, :label => 'Monthly snapshots to retain',

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -17,10 +17,16 @@
     <% end %>
     <% f.inputs :name => "Backup config", :class => 'separator' do %>
       <%= f.input :interval_hours, :required => true %>
-      <%= f.input :keep_snapshots, :required => true, :label => 'Keep this number of snapshots' %>
-      <%= f.input :retention_days, :required => false, :label => 'Retain how many daily snapshots' %>
-      <%= f.input :retention_weeks, :required => false, :label => 'Retain how many weekly snapshots' %>
-      <%= f.input :retention_months, :required => false, :label => 'Retain how many monthly snapshots' %>
+      <%= f.input :keep_snapshots, :required => true, :label => 'Keep this number of snapshots',
+        :hint => 'Normally, Retcon uses this value as the maximum number of snapshots to keep. ' +
+        'This setting will be overridden if daily retention is defined. ' +
+        'In both cases, this setting affects the number of job logs that Retcon keeps.' %>
+      <%= f.input :retention_days, :required => false, :label => 'Daily snapshots to retain' %>
+      <%= f.input :retention_weeks, :required => false, :label => 'Weekly snapshots to retain' %>
+      <%= f.input :retention_months, :required => false, :label => 'Monthly snapshots to retain',
+        :hint => 'Normally, leave daily, weekly and monthly fields blank. Defining daily retention ' +
+        'enables an algorithm that cleans up snapshots based on their distribution in time. ' +
+        'This is used only when a special agreement with the customer is in place.' %>
       <%= f.input :window_start, :required => false, :hint => 'Integer 0-23. Window starts at 0:00 when empty.' %>
       <%= f.input :window_stop, :required => false, :hint => 'Integer 0-23. Window ends at 23:59 when empty.' %>
       <%= f.input :profiles, :collection => Profile.public_plus(@server.hostname).find(:all, :order => 'name ASC'), :as => :check_boxes, :required => false %><br/>

--- a/app/views/servers/_form.html.erb
+++ b/app/views/servers/_form.html.erb
@@ -18,6 +18,9 @@
     <% f.inputs :name => "Backup config", :class => 'separator' do %>
       <%= f.input :interval_hours, :required => true %>
       <%= f.input :keep_snapshots, :required => true, :label => 'Keep this number of snapshots' %>
+      <%= f.input :retention_days, :required => false, :label => 'Retain how many daily snapshots' %>
+      <%= f.input :retention_weeks, :required => false, :label => 'Retain how many weekly snapshots' %>
+      <%= f.input :retention_months, :required => false, :label => 'Retain how many monthly snapshots' %>
       <%= f.input :window_start, :required => false, :hint => 'Integer 0-23. Window starts at 0:00 when empty.' %>
       <%= f.input :window_stop, :required => false, :hint => 'Integer 0-23. Window ends at 23:59 when empty.' %>
       <%= f.input :profiles, :collection => Profile.public_plus(@server.hostname).find(:all, :order => 'name ASC'), :as => :check_boxes, :required => false %><br/>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -40,7 +40,7 @@
 <tbody>
 <tr>
   <td><%=h @server.path || '/' %></td>
-  <td><%=h @server.keep_snapshots %></td>
+  <td><%=h display_retention @server %></td>
   <td><%=h @server.interval_hours %></td>
   <td><%=h @server.window_start %></td>
   <td><%=h @server.window_stop %></td>

--- a/db/migrate/20150511123517_add_retention2_to_server.rb
+++ b/db/migrate/20150511123517_add_retention2_to_server.rb
@@ -1,0 +1,13 @@
+class AddRetention2ToServer < ActiveRecord::Migration
+  def self.up
+    add_column :servers, :retention_days, :integer
+    add_column :servers, :retention_weeks, :integer
+    add_column :servers, :retention_months, :integer
+  end
+
+  def self.down
+    remove_column :servers, :retention_months
+    remove_column :servers, :retention_weeks
+    remove_column :servers, :retention_days
+  end
+end


### PR DESCRIPTION
This feature implements a more granular retention scheme, then ensures that within brackets of daily, weekly and monthly backups, no more than a given number of snapshots are retained.

The removal mechanism favors the snapshot with its closest successor in time, to optimize the spread of snapshots across time.
